### PR TITLE
Secretdetection exclusion feature

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:  # This allows manual trigger
   workflow_call:  # Allows this workflow to be reusable by other repositories
       inputs:
-        sast_exclude_list:
+        SAST_EXCLUDE_LIST:
           required: false
           type: string # space separated list of files/folders to exclude from scan
       secrets:
@@ -29,9 +29,9 @@ jobs:
         token: ${{ secrets.GLOBAL_REPO_TOKEN || github.token }}
       
     # Step 2: Remove sast_exclude_list
-    - name: Remove specified files/directories in sast_exclude_list
+    - name: Remove specified files/directories in SAST_EXCLUDE_LIST
       run: |
-        for item in ${{ inputs.sast_exclude_list }}; do
+        for item in ${{ inputs.SAST_EXCLUDE_LIST }}; do
           rm -rf $item
         done
         

--- a/.github/workflows/secret-detection.yml
+++ b/.github/workflows/secret-detection.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:  # Allows manual trigger
   workflow_call:  # Allows this workflow to be reusable by other repositories
     inputs:
-      secret_detection_exclude_list:
+      sd_exclude_list:
         required: false
         type: string # space separated list of files/folders to exclude from scan
     secrets:
@@ -36,6 +36,7 @@ jobs:
     # Step 3: run the scan
     - name: Run Gitleaks Scan
       run: | # Set the working directory to /path to avoid adding any prefix to file paths in Defectdojo
+       ls
        docker run -v ${PWD}:/path -w /path zricethezav/gitleaks:latest dir --exit-code 0 --report-path gitleaks-report.json .
     
     # Step 4: Fetching Binaries for Teleport

--- a/.github/workflows/secret-detection.yml
+++ b/.github/workflows/secret-detection.yml
@@ -3,6 +3,10 @@ name: Secret Detection
 on:
   workflow_dispatch:  # Allows manual trigger
   workflow_call:  # Allows this workflow to be reusable by other repositories
+    inputs:
+      secret_detection_exclude_list:
+        required: false
+        type: string # space separated list of files/folders to exclude from scan
     secrets:
       GLOBAL_REPO_TOKEN:
         required: false
@@ -21,19 +25,26 @@ jobs:
       uses: actions/checkout@v4
       with: #if the repo is public and GLOBAL_REPO_TOKEN is not present, we use the default token generated in the Github action to prevent errors
         token: ${{ secrets.GLOBAL_REPO_TOKEN || github.token }}
-
-    # Step 2: run the scan
+    
+    # Step 2: Remove secret_detection_exclude_list
+    - name: Remove specified files/directories in secret_detection_exclude_list
+      run: |
+        for item in ${{ inputs.secret_detection_exclude_list }}; do
+          rm -rf $item
+        done
+        
+    # Step 3: run the scan
     - name: Run Gitleaks Scan
       run: | # Set the working directory to /path to avoid adding any prefix to file paths in Defectdojo
        docker run -v ${PWD}:/path -w /path zricethezav/gitleaks:latest dir --exit-code 0 --report-path gitleaks-report.json .
     
-    # Step 3: Fetching Binaries for Teleport
+    # Step 4: Fetching Binaries for Teleport
     - name: Fetch Teleport Binaries
       uses: teleport-actions/setup@v1
       with:
         version: 16.2.0
     
-    # Step 4: Fetching Credentials
+    # Step 5: Fetching Credentials
     - name: Fetch Credentials Using Machine ID
       id: auth
       uses: teleport-actions/auth-application@v2
@@ -43,14 +54,14 @@ jobs:
         app: defectdojo
         anonymous-telemetry: 0
 
-    # Step 5: Upload to Defectdojo Behind Teleport
+    # Step 6: Upload to Defectdojo Behind Teleport
     - name: Upload Gitleaks JSON Report to Defectdojo
       run: |
         TODAY=$(date +%Y-%m-%d)
         product_name=$(echo "${GITHUB_REPOSITORY}" | cut -d'/' -f2)
         curl --cert ${{ steps.auth.outputs.certificate-file }} --key ${{ steps.auth.outputs.key-file }} -X "POST" "https://defectdojo.teleport.qlub.cloud/api/v2/import-scan/" -H "accept: application/json" -H "Authorization: Token ${{ secrets.DEFECTDOJO_TOKEN }}" -H "Content-Type: multipart/form-data" -F file=@gitleaks-report.json -F "product_type_name=Clubpay" -F "active=true" -F "verified=true" -F "close_old_findings=true" -F "engagement_name=${GITHUB_RUN_ID}(Secret-Detection)" -F "build_id=${GITHUB_RUN_ID}" -F "minimum_severity=Info" -F "close_old_findings_product_scope=true" -F "scan_date=$TODAY" -F "engagement_end_date=$TODAY" -F "commit_hash=${GITHUB_SHA}" -F "product_name=${product_name}" -F "auto_create_context=true" -F "scan_type=Gitleaks Scan" -F "branch_tag=${GITHUB_REF_NAME}" -F "source_code_management_uri=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
     
-    # Step 6: Upload the Gitleaks report as an artifact
+    # Step 7: Upload the Gitleaks report as an artifact
     - name: Upload Gitleaks Report to Artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/secret-detection.yml
+++ b/.github/workflows/secret-detection.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:  # Allows manual trigger
   workflow_call:  # Allows this workflow to be reusable by other repositories
     inputs:
-      sd_exclude_list:
+      SECRET_DETECTION_EXCLUDE_LIST:
         required: false
         type: string # space separated list of files/folders to exclude from scan
     secrets:
@@ -27,9 +27,9 @@ jobs:
         token: ${{ secrets.GLOBAL_REPO_TOKEN || github.token }}
     
     # Step 2: Remove secret_detection_exclude_list
-    - name: Remove specified files/directories in secret_detection_exclude_list
+    - name: Remove specified files/directories in SECRET_DETECTION_EXCLUDE_LIST
       run: |
-        for item in ${{ inputs.secret_detection_exclude_list }}; do
+        for item in ${{ inputs.SECRET_DETECTION_EXCLUDE_LIST }}; do
           rm -rf $item
         done
         

--- a/.github/workflows/secret-detection.yml
+++ b/.github/workflows/secret-detection.yml
@@ -29,6 +29,8 @@ jobs:
     # Step 2: Remove secret_detection_exclude_list
     - name: Remove specified files/directories in SECRET_DETECTION_EXCLUDE_LIST
       run: |
+        ls
+        ls services/community/certs
         for item in ${{ inputs.SECRET_DETECTION_EXCLUDE_LIST }}; do
           rm -rf $item
         done
@@ -37,6 +39,7 @@ jobs:
     - name: Run Gitleaks Scan
       run: | # Set the working directory to /path to avoid adding any prefix to file paths in Defectdojo
        ls
+       ls services/community/certs
        docker run -v ${PWD}:/path -w /path zricethezav/gitleaks:latest dir --exit-code 0 --report-path gitleaks-report.json .
     
     # Step 4: Fetching Binaries for Teleport

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ You can skip certain files, folders, or lines from being scanned by SecureFlow.
 
 Important Considerations:
 
-- Documentation: Always add a comment explaining why you're suppressing the rule. This helps other developers understand your decision and avoids accidentally re-introducing the vulnerability.
-- Review: Regularly review your skipped codes to ensure they still need to be skipped. Security landscapes change, and previously acceptable suppressions might become risky.
+- Documentation: Always add a note explaining why you're skipping the specific line of code. This helps other developers understand your decision and avoids accidentally re-introducing the vulnerability.
+- Review: Regularly review your skipped codes to ensure they still need to be skipped. Security landscapes change, and previously acceptable suppressions might become risky later.
 - Alternative: If possible, prefer fixing the underlying vulnerability rather than excluding the code. Skipping should be a last resort.
 
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ jobs:
 ```
 ## Skipping Files or Lines from Scanning
 
-You can skip certain files, folders, or lines from being scanned by the DevSecOps framework.
+You can skip certain files, folders, or lines from being scanned by SecureFlow.
 
 ### 1. Skip Specific Lines
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ def my_function():
 
 my_function()
 ```
-### 1. Skip Files and Directories
+### 2. Skip Files and Directories
 
 You can exclude specific directories or files from SAST and secret detection scans by using the **SAST_EXCLUDE_LIST** and **SECRET_DETECTION_EXCLUDE_LIST** variables. These variables accept a space-separated list of file and directory names that should be ignored during scanning. To apply these exclusions, you can reuse the workflows **with** these variables.
 ```yaml

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ You can skip certain files, folders, or lines from being scanned by SecureFlow.
 ### 1. Skip Specific Lines
 
 If you want to ignore specific lines of code, you can add in-line comments at the end of the target line of code. Use **nosemgrep** comment to skip SAST scans, and **gitleaks:allow** comment to skip secret detection.
-Skipping SAST Scans:
+
+Skipping SAST Scans (Example):
 ```code
 bad_func1()  #nosemgrep
 
@@ -144,7 +145,7 @@ bad_func3(   //nosemgrep
 );
 ```
 Skipping Secrets (Example 1):
-```code
+```go
 package main
 import "fmt"
 
@@ -154,7 +155,7 @@ func main() {
 }
 ```
 Skipping Secrets (Example 2):
-```code
+```python
 DB_PASSWORD = "TestDBPassword"  #gitleaks:allow
 
 def my_function():

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ You can skip certain files, folders, or lines from being scanned by the DevSecOp
 ### 1. Skip Specific Lines
 
 If you want to ignore specific lines of code, you can add in-line comments at the end of the target line of code. Use **nosemgrep** comment to skip SAST scans, and **gitleaks:allow** comment to skip secret detection.
-
+Skipping SAST Scans:
 ```code
 bad_func1()  #nosemgrep
 
@@ -143,6 +143,7 @@ bad_func3(   //nosemgrep
     arg
 );
 ```
+Skipping Secrets (Example 1):
 ```code
 package main
 import "fmt"
@@ -152,6 +153,7 @@ func main() {
     fmt.Println("API Key:", apiKey)
 }
 ```
+Skipping Secrets (Example 2):
 ```code
 DB_PASSWORD = "TestDBPassword"  #gitleaks:allow
 
@@ -162,7 +164,7 @@ my_function()
 ```
 ### 1. Skip Files and Directories
 
-You can exclude specific directories or files from SAST and secret detection scans by using the **SAST_EXCLUDE_LIST** and **SECRET_DETECTION_EXCLUDE_LIST** variables. These variables accept a space-separated list of file and directory names that should be ignored during scanning. To apply these exclusions, reuse the workflows by providing these variables.
+You can exclude specific directories or files from SAST and secret detection scans by using the **SAST_EXCLUDE_LIST** and **SECRET_DETECTION_EXCLUDE_LIST** variables. These variables accept a space-separated list of file and directory names that should be ignored during scanning. To apply these exclusions, you can reuse the workflows **with** these variables.
 ```yaml
 jobs:
   sast:
@@ -173,7 +175,7 @@ jobs:
       GLOBAL_REPO_TOKEN: ${{ secrets.GLOBAL_REPO_TOKEN }}
       DEFECTDOJO_TOKEN: ${{ secrets.DEFECTDOJO_TOKEN }}
     permissions:
-      id-token: write #This is essential for authentication to Teleport
+      id-token: write
 
   secret-detection:
     uses: clubpay/secureflow/.github/workflows/secret-detection.yml@main

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ jobs:
   sast:
     uses: clubpay/secureflow/.github/workflows/sast.yml@main
     with:
-      SAST_EXCLUDE_LIST: "services/community/certs/server.key README.md MyAwsomeDirectory staging.env"
+      SAST_EXCLUDE_LIST: "community/certs/server.key README.md MyAwsomeDirectory stage.env"
     secrets:
       GLOBAL_REPO_TOKEN: ${{ secrets.GLOBAL_REPO_TOKEN }}
       DEFECTDOJO_TOKEN: ${{ secrets.DEFECTDOJO_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ jobs:
   secret-detection:
     uses: clubpay/secureflow/.github/workflows/secret-detection.yml@main
     with:
-      SECRET_DETECTION_EXCLUDE_LIST: "services/community/community.go mock.go README.md MyAwsomeDirectory"
+      SECRET_DETECTION_EXCLUDE_LIST: "services/community.go mock.go README.md AwsomeDirectory"
     secrets:
       GLOBAL_REPO_TOKEN: ${{ secrets.GLOBAL_REPO_TOKEN }}
       DEFECTDOJO_TOKEN: ${{ secrets.DEFECTDOJO_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -126,6 +126,64 @@ jobs:
       id-token: write
 
 ```
+## Skipping Files or Lines from Scanning
 
+You can skip certain files, folders, or lines from being scanned by the DevSecOps framework.
+
+### 1. Skip Specific Lines
+
+If you want to ignore specific lines of code, you can add in-line comments at the end of the target line of code. Use **nosemgrep** comment to skip SAST scans, and **gitleaks:allow** comment to skip secret detection.
+
+```code
+bad_func1()  #nosemgrep
+
+bad_func2(); //nosemgrep
+
+bad_func3(   //nosemgrep
+    arg
+);
+```
+```code
+package main
+import "fmt"
+
+func main() {
+    apiKey := "THIS_IS_A_SAMPLE_API_KEY" //gitleaks:allow 
+    fmt.Println("API Key:", apiKey)
+}
+```
+```code
+DB_PASSWORD = "TestDBPassword"  #gitleaks:allow
+
+def my_function():
+#sample funcion to read from DB
+
+my_function()
+```
+### 1. Skip Files and Directories
+
+You can exclude specific directories or files from SAST and secret detection scans by using the **SAST_EXCLUDE_LIST** and **SECRET_DETECTION_EXCLUDE_LIST** variables. These variables accept a space-separated list of file and directory names that should be ignored during scanning. To apply these exclusions, reuse the workflows by providing these variables.
+```yaml
+jobs:
+  sast:
+    uses: clubpay/secureflow/.github/workflows/sast.yml@main
+    with:
+      SAST_EXCLUDE_LIST: "services/community/certs/server.key README.md MyAwsomeDirectory staging.env"
+    secrets:
+      GLOBAL_REPO_TOKEN: ${{ secrets.GLOBAL_REPO_TOKEN }}
+      DEFECTDOJO_TOKEN: ${{ secrets.DEFECTDOJO_TOKEN }}
+    permissions:
+      id-token: write #This is essential for authentication to Teleport
+
+  secret-detection:
+    uses: clubpay/secureflow/.github/workflows/secret-detection.yml@main
+    with:
+      SECRET_DETECTION_EXCLUDE_LIST: "services/community/community.go mock.go README.md MyAwsomeDirectory"
+    secrets:
+      GLOBAL_REPO_TOKEN: ${{ secrets.GLOBAL_REPO_TOKEN }}
+      DEFECTDOJO_TOKEN: ${{ secrets.DEFECTDOJO_TOKEN }}
+    permissions:
+      id-token: write
+```
 ## Note for Private Repositories
 For private repositories, it's essential to configure an action secret named **GLOBAL_REPO_TOKEN** with the appropriate permissions. Ensure that the token has both repository (repo) and workflow (workflow) access, allowing GitHub Actions to authenticate and execute workflows smoothly. Without this, attempts to access private repositories during checkout or workflow execution will fail due to insufficient authorization.

--- a/README.md
+++ b/README.md
@@ -130,19 +130,42 @@ jobs:
 
 You can skip certain files, folders, or lines from being scanned by SecureFlow.
 
+Important Considerations:
+
+- Documentation: Always add a comment explaining why you're suppressing the rule. This helps other developers understand your decision and avoids accidentally re-introducing the vulnerability.
+- Review: Regularly review your skipped codes to ensure they still need to be skipped. Security landscapes change, and previously acceptable suppressions might become risky.
+- Alternative: If possible, prefer fixing the underlying vulnerability rather than excluding the code. Skipping should be a last resort.
+
+
 ### 1. Skip Specific Lines
 
 If you want to ignore specific lines of code, you can add in-line comments at the end of the target line of code. Use **nosemgrep** comment to skip SAST scans, and **gitleaks:allow** comment to skip secret detection.
 
-Skipping SAST Scans (Example):
-```code
-bad_func1()  #nosemgrep
+Skipping SAST Scans (Example 1):
+```python
+import os
 
-bad_func2(); //nosemgrep
+def get_user_input():
+  user_input = input("Enter something: ") #nosemgrep
+  print(f"You entered: {user_input}")
+  return user_input
 
-bad_func3(   //nosemgrep
-    arg
-);
+if __name__ == "__main__":
+  get_user_input()
+```
+Skipping SAST Scans (Example 2):
+```go
+package main
+
+import (
+    "fmt"
+    "os"
+)
+
+func main() {
+    command := os.Getenv("MY_COMMAND") //nosemgrep
+    fmt.Println("Executing:", command)
+}
 ```
 Skipping Secrets (Example 1):
 ```go


### PR DESCRIPTION
Add inline commenting instruction in README to skip secret detection and SAST scans for a specific line of code.
Add exclusion ability for files/directories in Secret Detection. Changed the exclusion list variable name for SAST scans to SAST_EXCLUDE_LIST.