### PR TITLE
Aggregate SCA

### DIFF
--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -1,8 +1,8 @@
 name: Software Composition Analysis
 
 on:
-  workflow_dispatch:  # This allows manual trigger
-  workflow_call:  # Allows this workflow to be reusable by other repositories
+  workflow_dispatch:
+  workflow_call:
     secrets:
       GLOBAL_REPO_TOKEN:
         required: false
@@ -16,37 +16,70 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    # Step 1: Checkout the code from the repository
+    # Step 1: Checkout the code
     - name: Checkout Repository
       uses: actions/checkout@v4
-      with: #if the repo is public and GLOBAL_REPO_TOKEN is not present, we use the default token generated in the Github action to prevent errors
+      with:
         token: ${{ secrets.GLOBAL_REPO_TOKEN || github.token }}
 
-# Step 2: Install Syft and Grype
+    # Step 2: Install Syft and Grype tools
     - name: Install Syft and Grype
       run: |
         curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
         curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
 
-# Step 3: Generate SBOM using Syft
+    # Step 3: Generate SBOM from the project
     - name: Generate SBOM
       run: |
         /usr/local/bin/syft version
         /usr/local/bin/syft . -v -o json > sbom.json
 
- # Step 4: Scan SBOM Using Grype
+    # Step 4: Scan the SBOM with Grype to detect vulnerabilities
     - name: Scan SBOM with Grype
       run: |
         /usr/local/bin/grype version
         /usr/local/bin/grype sbom:sbom.json -v -o json > grype-report.json
-        
-  # Step 5: Fetching Binaries for Teleport
+
+    # Step 5: Deduplicate findings by dependency, keeping only the highest-severity issue for each one
+    - name: Deduplicate Grype Findings
+      run: |
+        python3 - <<EOF
+        import json
+
+        # Define severity precedence
+        severity_order = {"Critical": 5, "High": 4, "Medium": 3, "Low": 2, "Negligible": 1, "Unknown": 0}
+
+        # Load full grype report
+        with open("grype-report.json") as f:
+            data = json.load(f)
+
+        unique = {}
+
+        # Iterate through all matches
+        for m in data.get("matches", []):
+            artifact = m.get("artifact", {})
+            vuln = m.get("vulnerability", {})
+
+            # Use artifact name + version as unique dependency key
+            key = f"{artifact.get('name')}@{artifact.get('version')}"
+            severity = vuln.get("severity", "Unknown")
+
+            # Keep only the highest severity match for this dependency
+            if key not in unique or severity_order.get(severity, 0) > severity_order.get(unique[key]["vulnerability"]["severity"], 0):
+                unique[key] = m
+
+        # Write the reduced report
+        with open("grype-report-deduplicated.json", "w") as out:
+            json.dump({"matches": list(unique.values())}, out, indent=2)
+        EOF
+
+    # Step 6: Fetch Teleport CLI
     - name: Fetch Teleport Binaries
       uses: teleport-actions/setup@v1
       with:
         version: 16.2.0
-        
-  # Step 6: Fetching Credentials
+
+    # Step 7: Authenticate with DefectDojo through Teleport
     - name: Fetch Credentials Using Machine ID
       id: auth
       uses: teleport-actions/auth-application@v2
@@ -55,17 +88,24 @@ jobs:
         token: defectdojo-github-action
         app: defectdojo
         anonymous-telemetry: 0
- 
- # Step 7: Upload the Grype's report to DefectDojo
-    - name: Upload Grype Report to Defectdojo
+
+    # Step 8: Upload deduplicated Grype report to DefectDojo
+    - name: Upload Deduplicated Grype Report to Defectdojo
       run: |
         TODAY=$(date +%Y-%m-%d)
         product_name=$(echo "${GITHUB_REPOSITORY}" | cut -d'/' -f2)
-        curl --cert ${{ steps.auth.outputs.certificate-file }} --key ${{ steps.auth.outputs.key-file }} -X "POST" "https://defectdojo.teleport.qlub.cloud/api/v2/import-scan/" -H "accept: application/json" -H "Authorization: Token ${{ secrets.DEFECTDOJO_TOKEN }}" -H "Content-Type: multipart/form-data" -F file=@grype-report.json -F "product_type_name=Clubpay" -F "active=true" -F "verified=true" -F "close_old_findings=true" -F "engagement_name=${GITHUB_RUN_ID}(SCA)" -F "build_id=${GITHUB_RUN_ID}" -F "minimum_severity=Info" -F "close_old_findings_product_scope=true" -F "scan_date=$TODAY" -F "engagement_end_date=$TODAY" -F "commit_hash=${GITHUB_SHA}" -F "product_name=${product_name}" -F "auto_create_context=true" -F "scan_type=Anchore Grype" -F "branch_tag=${GITHUB_REF_NAME}" -F "source_code_management_uri=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+        curl --cert ${{ steps.auth.outputs.certificate-file }} --key ${{ steps.auth.outputs.key-file }} -X "POST" "https://defectdojo.teleport.qlub.cloud/api/v2/import-scan/" -H "accept: application/json" -H "Authorization: Token ${{ secrets.DEFECTDOJO_TOKEN }}" -H "Content-Type: multipart/form-data" -F file=@grype-report-deduplicated.json -F "product_type_name=Clubpay" -F "active=true" -F "verified=true" -F "close_old_findings=true" -F "engagement_name=${GITHUB_RUN_ID}(SCA)" -F "build_id=${GITHUB_RUN_ID}" -F "minimum_severity=Info" -F "close_old_findings_product_scope=true" -F "scan_date=$TODAY" -F "engagement_end_date=$TODAY" -F "commit_hash=${GITHUB_SHA}" -F "product_name=${product_name}" -F "auto_create_context=true" -F "scan_type=Anchore Grype" -F "branch_tag=${GITHUB_REF_NAME}" -F "source_code_management_uri=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
 
- # Step 8: Upload the Grype report as an artifact
-    - name: Upload Grype Report to Artifacts
+    # Step 9: Upload original Grype report for reference/debugging
+    - name: Upload Original Grype Report
       uses: actions/upload-artifact@v4
       with:
-        name: grype-report
+        name: grype-report-original
         path: grype-report.json
+
+    # Step 10: Upload deduplicated Grype report used for upload
+    - name: Upload Deduplicated Grype Report
+      uses: actions/upload-artifact@v4
+      with:
+        name: grype-report-deduplicated
+        path: grype-report-deduplicated.json

--- a/sample/go.mod
+++ b/sample/go.mod
@@ -74,6 +74,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/nats-io/nats-streaming-server v0.25.4 // indirect
 	github.com/nats-io/nkeys v0.4.4 // indirect
+	github.com/nats-io/nkeys v0.4.2 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect


### PR DESCRIPTION
Post-process the Grype JSON output (grype-report.json) to aggregate vulnerabilities by dependency name.

Keep only the finding with the highest severity (Critical > High > Medium > Low > Unknown > Negligible).

Output a new JSON file that includes only those findings.

Upload that filtered report to DefectDojo.