### PR TITLE
Rewrite Exclusion

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -31,17 +31,27 @@ jobs:
     # Step 2: Remove sast_exclude_list
     - name: Remove specified files/directories in SAST_EXCLUDE_LIST
       shell: bash
-      run: |
+      run: |     
+       # Create a temporary ignore file with user-provided patterns
         ls
         ls ./openapi-spec
-        shopt -s nullglob globstar
-        for pattern in ${{ inputs.SAST_EXCLUDE_LIST }}; do
-          echo "Removing: $pattern"
-          rm -rf $pattern
-        done
-        ls
-        ls ./openapi-spec
+        echo "${{ inputs.SAST_EXCLUDE_LIST }}" | tr ' ' '\n' > .tempignore
 
+        echo "Exclusion patterns:"
+        cat .tempignore
+
+        # Use gitignore-style matching to find files
+        # -c : cached/tracked
+        # -o : others (untracked)
+        # --exclude-from : apply ignore rules
+        git ls-files -co --exclude-from=.tempignore | while read file; do
+          echo "Removing: $file"
+          rm -rf "$file"
+        done
+
+        rm .tempignore
+        ls
+        ls ./openapi-spec
     # Step 3: Run Semgrep scan on all files and output to a JSON file
     - name: Run Semgrep Scan
       run: |

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -112,7 +112,7 @@ jobs:
           echo "Removing: $f"
           rm -rf "$f"
         done
-        ls
+        
     # Step 3: Run Semgrep scan on all files and output to a JSON file
     - name: Run Semgrep Scan
       run: |

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -29,38 +29,95 @@ jobs:
         token: ${{ secrets.GLOBAL_REPO_TOKEN || github.token }}
       
     # Step 2: Remove sast_exclude_list
-    - name: Remove files/dirs matching SAST_EXCLUDE_LIST (gitignore semantics)
+    - name: Remove files/dirs according to gitignore-style patterns
       shell: bash
       run: |
-        ls
-        ls openapi-spec
+        ls 
         ls docs
         ls docs/images
+        ls openapi-spec
         set -euo pipefail
-
-        # 1) Write patterns to a temp file (space- or newline-separated input supported)
-        #    This file uses .gitignore syntax.
-        printf "%s\n" ${{ inputs.SAST_EXCLUDE_LIST }} | tr ' ' '\n' > .sastignore.tmp
-
-        echo "Exclusion patterns:"
-        nl -ba .sastignore.tmp || cat .sastignore.tmp
-
-        # 2) Ask Git to list ONLY paths (tracked + untracked) that MATCH those patterns.
-        #    -c: include tracked files
-        #    -o: include untracked files
-        #    -i/--ignored: show only items that match the exclude patterns
-        #    --exclude-from: read patterns from our temp file (gitignore format)
-        #    --directory: if an entire untracked dir matches, list the dir itself
-        #    -z: NUL-delimit results so we can safely xargs them
-        git ls-files -c -o -i --ignored --exclude-from=.sastignore.tmp --directory -z \
-          | xargs -0 -r rm -rf
-
-        # 3) Clean up (succeeds even if the temp file was matched and removed above)
-        rm -f .sastignore.tmp
-        ls
-        ls openapi-spec
+        shopt -s globstar nullglob dotglob
+    
+        # Convert space-separated SAST_EXCLUDE_LIST into array
+        read -ra patterns <<< "${{ inputs.SAST_EXCLUDE_LIST }}"
+    
+        # Array to store files/dirs to delete
+        declare -a to_delete=()
+    
+        for pattern in "${patterns[@]}"; do
+          # Skip blank lines and comments
+          [[ -z "$pattern" || "$pattern" =~ ^# ]] && continue
+    
+          # Handle negation
+          negate=false
+          if [[ "$pattern" == !* ]]; then
+            negate=true
+            pattern="${pattern:1}"
+          fi
+    
+          echo "Processing pattern: $pattern (negate=$negate)"
+    
+          # Determine if pattern is directory-only
+          dir_only=false
+          if [[ "$pattern" == */ ]]; then
+            dir_only=true
+            pattern="${pattern%/}"
+          fi
+    
+          # Root-only pattern
+          root_only=false
+          if [[ "$pattern" == /* ]]; then
+            root_only=true
+            pattern="${pattern#/}"
+          fi
+    
+          # Generate matches
+          matches=()
+          if $root_only; then
+            if $dir_only; then
+              [[ -d "$pattern" ]] && matches+=("$pattern")
+            else
+              [[ -e "$pattern" ]] && matches+=("$pattern")
+            fi
+          else
+            if $dir_only; then
+              # directories recursively
+              while IFS= read -r d; do
+                matches+=("$d")
+              done < <(find . -type d -path "./$pattern" 2>/dev/null)
+            else
+              # files and dirs recursively
+              while IFS= read -r f; do
+                matches+=("$f")
+              done < <(find . -path "./$pattern" 2>/dev/null)
+            fi
+          fi
+    
+          # Apply negation: remove from deletion list
+          if $negate; then
+            for m in "${matches[@]}"; do
+              for i in "${!to_delete[@]}"; do
+                [[ "${to_delete[i]}" == "$m" ]] && unset 'to_delete[i]'
+              done
+            done
+          else
+            to_delete+=("${matches[@]}")
+          fi
+        done
+    
+        # Remove duplicates
+        IFS=$'\n' read -r -d '' -a to_delete < <(printf '%s\n' "${to_delete[@]}" | sort -u && printf '\0')
+    
+        # Delete all collected files/dirs
+        for f in "${to_delete[@]}"; do
+          echo "Removing: $f"
+          rm -rf "$f"
+        done
+        ls 
         ls docs
         ls docs/images
+        ls openapi-spec
     # Step 3: Run Semgrep scan on all files and output to a JSON file
     - name: Run Semgrep Scan
       run: |

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -35,7 +35,7 @@ jobs:
         ls
         ls openapi-spec
         ls docs
-        ls images
+        ls docs/images
         set -euo pipefail
 
         # 1) Write patterns to a temp file (space- or newline-separated input supported)
@@ -60,7 +60,7 @@ jobs:
         ls
         ls openapi-spec
         ls docs
-        ls images
+        ls docs/images
     # Step 3: Run Semgrep scan on all files and output to a JSON file
     - name: Run Semgrep Scan
       run: |

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -35,6 +35,7 @@ jobs:
         ls
         ls openapi-spec
         ls docs
+        ls images
         set -euo pipefail
 
         # 1) Write patterns to a temp file (space- or newline-separated input supported)
@@ -59,6 +60,7 @@ jobs:
         ls
         ls openapi-spec
         ls docs
+        ls images
     # Step 3: Run Semgrep scan on all files and output to a JSON file
     - name: Run Semgrep Scan
       run: |

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -34,6 +34,7 @@ jobs:
       run: |
         ls
         ls openapi-spec
+        ls docs
         set -euo pipefail
 
         # 1) Write patterns to a temp file (space- or newline-separated input supported)
@@ -57,6 +58,7 @@ jobs:
         rm -f .sastignore.tmp
         ls
         ls openapi-spec
+        ls docs
     # Step 3: Run Semgrep scan on all files and output to a JSON file
     - name: Run Semgrep Scan
       run: |

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -30,11 +30,14 @@ jobs:
       
     # Step 2: Remove sast_exclude_list
     - name: Remove specified files/directories in SAST_EXCLUDE_LIST
+      shell: bash
       run: |
-        for item in ${{ inputs.SAST_EXCLUDE_LIST }}; do
-          rm -rf $item
+        shopt -s nullglob globstar
+        for pattern in ${{ inputs.SAST_EXCLUDE_LIST }}; do
+          echo "Removing: $pattern"
+          rm -rf $pattern
         done
-        
+
     # Step 3: Run Semgrep scan on all files and output to a JSON file
     - name: Run Semgrep Scan
       run: |

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -32,11 +32,15 @@ jobs:
     - name: Remove specified files/directories in SAST_EXCLUDE_LIST
       shell: bash
       run: |
+        ls
+        ls ./openapi-spec
         shopt -s nullglob globstar
         for pattern in ${{ inputs.SAST_EXCLUDE_LIST }}; do
           echo "Removing: $pattern"
           rm -rf $pattern
         done
+        ls
+        ls ./openapi-spec
 
     # Step 3: Run Semgrep scan on all files and output to a JSON file
     - name: Run Semgrep Scan

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -31,8 +31,8 @@ jobs:
     # Step 2: Remove sast_exclude_list
     - name: Remove specified files/directories in SAST_EXCLUDE_LIST
       shell: bash
-      run: |     
-       # Create a temporary ignore file with user-provided patterns
+      run: |
+        # Write exclusion patterns to a temp file
         ls
         ls ./openapi-spec
         echo "${{ inputs.SAST_EXCLUDE_LIST }}" | tr ' ' '\n' > .tempignore
@@ -40,16 +40,18 @@ jobs:
         echo "Exclusion patterns:"
         cat .tempignore
 
-        # Use gitignore-style matching to find files
-        # -c : cached/tracked
-        # -o : others (untracked)
-        # --exclude-from : apply ignore rules
-        git ls-files -co --exclude-from=.tempignore | while read file; do
-          echo "Removing: $file"
-          rm -rf "$file"
-        done
+        # Ask git which files match these patterns
+        git ls-files -co | git check-ignore --stdin > .matches || true
 
-        rm .tempignore
+        echo "Matched files to remove:"
+        cat .matches || true
+
+        # Remove matched files/directories
+        if [ -s .matches ]; then
+          xargs rm -rf < .matches
+        fi
+
+        rm -f .tempignore .matches
         ls
         ls ./openapi-spec
     # Step 3: Run Semgrep scan on all files and output to a JSON file

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -29,31 +29,34 @@ jobs:
         token: ${{ secrets.GLOBAL_REPO_TOKEN || github.token }}
       
     # Step 2: Remove sast_exclude_list
-    - name: Remove specified files/directories in SAST_EXCLUDE_LIST
+    - name: Remove files/dirs matching SAST_EXCLUDE_LIST (gitignore semantics)
       shell: bash
       run: |
-        # Write exclusion patterns to a temp file
         ls
-        ls ./openapi-spec
-        echo "${{ inputs.SAST_EXCLUDE_LIST }}" | tr ' ' '\n' > .tempignore
+        ls openapi-spec
+        set -euo pipefail
+
+        # 1) Write patterns to a temp file (space- or newline-separated input supported)
+        #    This file uses .gitignore syntax.
+        printf "%s\n" ${{ inputs.SAST_EXCLUDE_LIST }} | tr ' ' '\n' > .sastignore.tmp
 
         echo "Exclusion patterns:"
-        cat .tempignore
+        nl -ba .sastignore.tmp || cat .sastignore.tmp
 
-        # Ask git which files match these patterns
-        git ls-files -co | git check-ignore --stdin > .matches || true
+        # 2) Ask Git to list ONLY paths (tracked + untracked) that MATCH those patterns.
+        #    -c: include tracked files
+        #    -o: include untracked files
+        #    -i/--ignored: show only items that match the exclude patterns
+        #    --exclude-from: read patterns from our temp file (gitignore format)
+        #    --directory: if an entire untracked dir matches, list the dir itself
+        #    -z: NUL-delimit results so we can safely xargs them
+        git ls-files -c -o -i --ignored --exclude-from=.sastignore.tmp --directory -z \
+          | xargs -0 -r rm -rf
 
-        echo "Matched files to remove:"
-        cat .matches || true
-
-        # Remove matched files/directories
-        if [ -s .matches ]; then
-          xargs rm -rf < .matches
-        fi
-
-        rm -f .tempignore .matches
+        # 3) Clean up (succeeds even if the temp file was matched and removed above)
+        rm -f .sastignore.tmp
         ls
-        ls ./openapi-spec
+        ls openapi-spec
     # Step 3: Run Semgrep scan on all files and output to a JSON file
     - name: Run Semgrep Scan
       run: |

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -32,8 +32,6 @@ jobs:
     - name: Remove files/dirs according to gitignore-style patterns
       shell: bash
       run: |
-        ls
-        ls openapi-spec
         set -euo pipefail
         shopt -s globstar nullglob dotglob
     
@@ -113,7 +111,6 @@ jobs:
           rm -rf "$f"
         done
         ls
-        ls openapi-spec
     # Step 3: Run Semgrep scan on all files and output to a JSON file
     - name: Run Semgrep Scan
       run: |

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -32,9 +32,7 @@ jobs:
     - name: Remove files/dirs according to gitignore-style patterns
       shell: bash
       run: |
-        ls 
-        ls docs
-        ls docs/images
+        ls
         ls openapi-spec
         set -euo pipefail
         shopt -s globstar nullglob dotglob
@@ -114,9 +112,7 @@ jobs:
           echo "Removing: $f"
           rm -rf "$f"
         done
-        ls 
-        ls docs
-        ls docs/images
+        ls
         ls openapi-spec
     # Step 3: Run Semgrep scan on all files and output to a JSON file
     - name: Run Semgrep Scan

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -32,7 +32,9 @@ jobs:
     - name: Remove files/dirs according to gitignore-style patterns
       shell: bash
       run: |
+        #Ensure safe execution (fail fast on errors, catch unset variables, detect pipeline errors)
         set -euo pipefail
+        #Enable flexible recursive globbing, including hidden files, and avoids issues with unmatched patterns
         shopt -s globstar nullglob dotglob
     
         # Convert space-separated SAST_EXCLUDE_LIST into array

--- a/.github/workflows/secret-detection.yml
+++ b/.github/workflows/secret-detection.yml
@@ -27,10 +27,88 @@ jobs:
         token: ${{ secrets.GLOBAL_REPO_TOKEN || github.token }}
     
     # Step 2: Remove secret_detection_exclude_list
-    - name: Remove specified files/directories in SECRET_DETECTION_EXCLUDE_LIST
+    - name: Remove files/dirs according to gitignore-style patterns
+      shell: bash
       run: |
-        for item in ${{ inputs.SECRET_DETECTION_EXCLUDE_LIST }}; do
-          rm -rf $item
+        #Ensure safe execution (fail fast on errors, catch unset variables, detect pipeline errors)
+        set -euo pipefail
+        #Enable flexible recursive globbing, including hidden files, and avoids issues with unmatched patterns
+        shopt -s globstar nullglob dotglob
+    
+        # Convert space-separated SECRET_DETECTION_EXCLUDE_LIST into array
+        read -ra patterns <<< "${{ inputs.SECRET_DETECTION_EXCLUDE_LIST }}"
+    
+        # Array to store files/dirs to delete
+        declare -a to_delete=()
+    
+        for pattern in "${patterns[@]}"; do
+          # Skip blank lines and comments
+          [[ -z "$pattern" || "$pattern" =~ ^# ]] && continue
+    
+          # Handle negation
+          negate=false
+          if [[ "$pattern" == !* ]]; then
+            negate=true
+            pattern="${pattern:1}"
+          fi
+    
+          echo "Processing pattern: $pattern (negate=$negate)"
+    
+          # Determine if pattern is directory-only
+          dir_only=false
+          if [[ "$pattern" == */ ]]; then
+            dir_only=true
+            pattern="${pattern%/}"
+          fi
+    
+          # Root-only pattern
+          root_only=false
+          if [[ "$pattern" == /* ]]; then
+            root_only=true
+            pattern="${pattern#/}"
+          fi
+    
+          # Generate matches
+          matches=()
+          if $root_only; then
+            if $dir_only; then
+              [[ -d "$pattern" ]] && matches+=("$pattern")
+            else
+              [[ -e "$pattern" ]] && matches+=("$pattern")
+            fi
+          else
+            if $dir_only; then
+              # directories recursively
+              while IFS= read -r d; do
+                matches+=("$d")
+              done < <(find . -type d -path "./$pattern" 2>/dev/null)
+            else
+              # files and dirs recursively
+              while IFS= read -r f; do
+                matches+=("$f")
+              done < <(find . -path "./$pattern" 2>/dev/null)
+            fi
+          fi
+    
+          # Apply negation: remove from deletion list
+          if $negate; then
+            for m in "${matches[@]}"; do
+              for i in "${!to_delete[@]}"; do
+                [[ "${to_delete[i]}" == "$m" ]] && unset 'to_delete[i]'
+              done
+            done
+          else
+            to_delete+=("${matches[@]}")
+          fi
+        done
+    
+        # Remove duplicates
+        IFS=$'\n' read -r -d '' -a to_delete < <(printf '%s\n' "${to_delete[@]}" | sort -u && printf '\0')
+    
+        # Delete all collected files/dirs
+        for f in "${to_delete[@]}"; do
+          echo "Removing: $f"
+          rm -rf "$f"
         done
         
     # Step 3: run the scan

--- a/README.md
+++ b/README.md
@@ -188,13 +188,23 @@ my_function()
 ```
 ### 2. Skip Files and Directories
 
-You can exclude specific directories or files from SAST and secret detection scans by using the **SAST_EXCLUDE_LIST** and **SECRET_DETECTION_EXCLUDE_LIST** variables. These variables accept a space-separated list of file and directory names that should be ignored during scanning. To apply these exclusions, you can reuse the workflows **with** these variables.
+You can exclude specific files or directories from SAST and secret detection scans by using the **SAST_EXCLUDE_LIST** and **SECRET_DETECTION_EXCLUDE_LIST** variables.
+
+These variables accept a **space-separated list of file or directory patterns**, following **`.gitignore` / `.semgrepignore` syntax**. This means you can use:
+
+- `*_test.go` → matches all `_test.go` files recursively
+- `docs/` → matches the `docs` directory at the repository root
+- `**/generated/` → matches any `generated` directory at any depth
+- `!important.txt` → re-includes a file that would otherwise be excluded
+
+To apply these exclusions, simply pass your patterns to the workflow via these variables when reusing it in your repository.
+
 ```yaml
 jobs:
   sast:
     uses: clubpay/secureflow/.github/workflows/sast.yml@main
     with:
-      SAST_EXCLUDE_LIST: "community/certs/server.key README.md MyAwsomeDirectory stage.env"
+      SAST_EXCLUDE_LIST: "**/generated/ docs/"
     secrets:
       GLOBAL_REPO_TOKEN: ${{ secrets.GLOBAL_REPO_TOKEN }}
       DEFECTDOJO_TOKEN: ${{ secrets.DEFECTDOJO_TOKEN }}
@@ -204,7 +214,7 @@ jobs:
   secret-detection:
     uses: clubpay/secureflow/.github/workflows/secret-detection.yml@main
     with:
-      SECRET_DETECTION_EXCLUDE_LIST: "services/community.go mock.go README.md AwsomeDirectory"
+      SECRET_DETECTION_EXCLUDE_LIST: "postman_collections/ *_test.go !DontRemove_test.go"
     secrets:
       GLOBAL_REPO_TOKEN: ${{ secrets.GLOBAL_REPO_TOKEN }}
       DEFECTDOJO_TOKEN: ${{ secrets.DEFECTDOJO_TOKEN }}


### PR DESCRIPTION
Update SAST and Secret Detection workflows to support .gitignore-style exclusions. The SAST_EXCLUDE_LIST and SECRET_DETECTION_EXCLUDE_LIST variables now accept space-separated patterns using .gitignore or .semgrepignore syntax. This ensures that files and directories specified in these lists are properly excluded from scans, including support for recursive matches, root-only directories, and negation patterns. The README has also been updated to clarify how to use these patterns in the workflows.
https://git-scm.com/docs/gitignore#_pattern_format